### PR TITLE
Here's a proposed change to address the CUDA linking issue in the CMa…

### DIFF
--- a/cuda-bsgs/CMakeLists.txt
+++ b/cuda-bsgs/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.18)
 project(CudaBSGS CXX CUDA) # Added CUDA language back
+enable_language(CUDA) # Explicitly enable CUDA language support
 
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 17)
@@ -58,8 +59,11 @@ if(BUILD_WITH_CUDA)
     set(CMAKE_CUDA_ARCHITECTURES ${CUDA_ARCHITECTURES})
     message(STATUS "Targeting CUDA Architectures: ${CMAKE_CUDA_ARCHITECTURES}")
 
-    # Using modern CMake targets for CUDA
-    target_link_libraries(cudabsgs PRIVATE CUDA::cudart)
+    # Ensure CUDA include directories are added
+    target_include_directories(cudabsgs PRIVATE ${CUDA_INCLUDE_DIRS})
+
+    # Link CUDA libraries using the variable
+    target_link_libraries(cudabsgs PRIVATE ${CUDA_LIBRARIES})
 
     # Add NVML if found and enabled
     if(WITH_NVML_MONITORING AND NVML_LIBRARY AND NVML_INCLUDE_DIR)


### PR DESCRIPTION
…ke configuration:

```
fix: Attempt to resolve CUDA::cudart linking issue in CMake

This commit applies two changes to cuda-bsgs/CMakeLists.txt to address
the "CUDA::cudart target not found" error you reported on a Linux environment
(CMake 3.22.1, CUDA 12.3).

1.  I've explicitly enabled CUDA language support by adding `enable_language(CUDA)`
    after the `project()` call. This can help ensure CMake fully initializes
    its CUDA support.

2.  I've modified the CUDA library linking to use the traditional CMake variables
    `${CUDA_LIBRARIES}` and `${CUDA_INCLUDE_DIRS}` instead of the modern
    imported target `CUDA::cudart`. This provides a fallback mechanism
    if the imported targets are not being correctly generated or recognized.
    - I added `target_include_directories(cudabsgs PRIVATE ${CUDA_INCLUDE_DIRS})`
    - I changed `target_link_libraries(cudabsgs PRIVATE CUDA::cudart)` to
      `target_link_libraries(cudabsgs PRIVATE ${CUDA_LIBRARIES})`

These changes are intended to make the CUDA linking process more robust
across different CMake and CUDA environment configurations.
```